### PR TITLE
Add Download Images as ZIP Feature for Smile Capture Sessions #ieeesoc

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -190,6 +190,9 @@
       <div class="button-container">
         <button onclick="loadCapturedImages()">Show Captured Images</button>
         <button onclick="smoothReload()">Done</button>
+        <a href="/download_images" style="text-decoration:none;">
+          <button type="button">Download All Images as ZIP</button>
+        </a>
       </div>
 
       <div class="captured-images" id="capturedImages"></div>

--- a/templates/show_case.html
+++ b/templates/show_case.html
@@ -39,6 +39,21 @@
         border: 2px solid #ff5733;
         background: #eee;
       }
+      .download-btn {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 10px 15px;
+        font-size: 1em;
+        color: #fff;
+        background: #ff5733;
+        border: none;
+        border-radius: 5px;
+        cursor: pointer;
+        text-decoration: none;
+      }
+      .download-btn:hover {
+        background: #e04527;
+      }
     </style>
   </head>
   <body>
@@ -51,6 +66,8 @@
         <img src="{{ img }}" alt="Smile Image" />
         {% endfor %}
       </div>
+      <a href="/static/images/{{ entry.id }}.zip" id="download-{{ entry.id }}" class="download-btn" style="display:none;">Download ZIP</a>
+      <button onclick="window.location.href='/download_images?id={{ entry.id }}'">Download Images as ZIP</button>
     </div>
     {% else %}
     <p>No images found.</p>


### PR DESCRIPTION
This PR introduces a new feature that allows users to download all captured images from their smile session as a ZIP file.

Key Changes:

- Added a /download_images Flask route that packages all images from the current session into a ZIP archive and serves it for download.
- Updated the UI (index.html and/or show_case.html) to include a "Download Images as ZIP" button, making it easy for users to retrieve all their photos at once.
![Screenshot (36)](https://github.com/user-attachments/assets/ec05deda-25b9-49ae-b8af-2c7216c93772)
